### PR TITLE
Remove note about bootstrap checks

### DIFF
--- a/docs/install-run/basic.rst
+++ b/docs/install-run/basic.rst
@@ -74,10 +74,6 @@ address.
 
    Consult the `CrateDB reference documentation`_ for help using this command.
 
-.. NOTE::
-
-   CrateDB performs a number of `bootstrap checks`_ on startup.
-
 
 Next steps
 ==========

--- a/docs/install-run/macos.rst
+++ b/docs/install-run/macos.rst
@@ -33,10 +33,6 @@ terminal application:
 If you don't already have `Java 11`_ installed, the above command will try to
 take care of that for you along with a few other housekeeping tasks.
 
-.. NOTE::
-
-   CrateDB performs a number of `bootstrap checks`_ on startup.
-
 
 Next steps
 ==========

--- a/docs/install-run/windows.rst
+++ b/docs/install-run/windows.rst
@@ -44,10 +44,6 @@ CrateDB, like so:
 
    PS> ./bin/crate
 
-.. NOTE::
-
-   CrateDB performs a number of `bootstrap checks`_ on startup.
-
 
 Next steps
 ==========


### PR DESCRIPTION
bootstrap checks only run when crate is configured to bind to a non-localhost address, so this note is superfluous here

this is ready for @crate/docs review and approval