### PR TITLE
Minor copyedit, including removal of :last-reviewed: metadata

### DIFF
--- a/docs/install-run/basic.rst
+++ b/docs/install-run/basic.rst
@@ -1,6 +1,3 @@
-.. meta::
-     :last-reviewed: 2020-07-09
-
 .. highlight:: sh
 
 .. _basic-install:
@@ -64,6 +61,8 @@ Once downloaded, unpack the tarball and change into the resulting directory:
    release.
 
 
+.. _run:
+
 Run
 ===
 
@@ -84,6 +83,8 @@ address.
 
    Consult the `CrateDB reference documentation`_ for help using this command.
 
+
+.. _next:
 
 Next steps
 ==========


### PR DESCRIPTION
Previously, the :last-reviewed: metadata was added to indicate that this file
received a content refresh.

Per <crate/tech-writing-domain#360>, we are now using Git commit keywords.
