### PR TITLE
Improvement: Add note about Windows Server, plus RST tidy up

### DIFF
--- a/docs/install-run/basic.rst
+++ b/docs/install-run/basic.rst
@@ -8,9 +8,9 @@ Basic tarball Installation
 
 .. CAUTION::
 
-   These instructions are designed to get you quickly up and running on your local
-   computer. For putting CrateDB into production, you can learn more about
-   `deploying`_ or `scaling`_ CrateDB in the `CrateDB Guide`_.
+   These instructions are designed to get you quickly up and running on your
+   local computer. For putting CrateDB into production, check out the `How-To
+   Guides`_.
 
 .. SEEALSO::
 
@@ -21,8 +21,10 @@ Basic tarball Installation
    :ref:`macOS <mac-install>`, :ref:`Microsoft Windows <windows-install>`, and
    :ref:`Docker <docker-install>`.
 
+
 Prerequisites
 =============
+
 CrateDB requires a `Java virtual machine`_ to run.
 
 .. NOTE::
@@ -33,6 +35,7 @@ CrateDB requires a `Java virtual machine`_ to run.
 Versions starting from 3.0 to 4.1 require a `Java 11`_ installation. We
 recommend using `Oracle's Java`_ on macOS and OpenJDK_ on Linux Systems.
 Earlier versions required Java 8.
+
 
 .. _install_targz:
 
@@ -60,15 +63,15 @@ Download
 Run
 ===
 
-You do not have to configure or build anything. Once unpacked, CrateDB can be started in the foreground like this:
+You do not have to configure or build anything. Once unpacked, CrateDB can be
+started in the foreground like this:
 
 .. code-block:: console
 
    sh$ ./bin/crate
 
 This command runs a single instance of CrateDB that is bound to the local IP
-address.
-:kbd:`Control-C` will stop the process.
+address. :kbd:`Control-C` will stop the process.
 
 .. SEEALSO::
 
@@ -87,9 +90,8 @@ Now you have CrateDB up and running, :ref:`take the guided tour <first-use>`.
 .. _An introductory tutorial: https://crate.io/docs/crate/guide/tutorials/hello.html
 .. _bootstrap checks: https://crate.io/docs/crate/guide/en/latest/admin/bootstrap-checks.html
 .. _crash: https://crate.io/docs/crate/guide/getting_started/connect/crash.html
-.. _CrateDB Guide: https://crate.io/docs/crate/guide/en/latest/
+.. _How-To Guides: https://crate.io/docs/crate/howtos/en/latest/
 .. _CrateDB reference documentation: https://crate.io/docs/crate/reference/en/latest/run.html
-.. _deploying: https://crate.io/docs/crate/guide/en/latest/deployment/index.html
 .. _How to run CrateDB in a multi node setup: https://crate.io/docs/crate/guide/getting_started/scale/multi_node_setup.html
 .. _install section: https://crate.io/docs/crate/guide/getting_started/install/index.html
 .. _Java 11: https://www.oracle.com/technetwork/java/javase/downloads/index.html
@@ -97,7 +99,6 @@ Now you have CrateDB up and running, :ref:`take the guided tour <first-use>`.
 .. _OpenJDK: https://openjdk.java.net/projects/jdk/11/
 .. _Oracle's Java: https://www.java.com/en/download/help/mac_install.xml
 .. _release notes: https://crate.io/docs/crate/reference/en/latest/release_notes/index.html
-.. _scaling: https://crate.io/docs/crate/guide/en/latest/scaling/index.html
 .. _the latest CrateDB release: https://crate.io/download/
 .. _Unix-like system: https://en.wikipedia.org/wiki/Unix-like
 .. _web administration interface: https://crate.io/docs/crate/guide/getting_started/connect/admin_ui.html

--- a/docs/install-run/docker.rst
+++ b/docs/install-run/docker.rst
@@ -1,8 +1,8 @@
 .. _docker-install:
 
-=====================
+=============
 Run on Docker
-=====================
+=============
 
 .. CAUTION::
 
@@ -16,6 +16,7 @@ Run on Docker
 CrateDB and Docker_ are a great match thanks to CrateDB's shared-nothing,
 horizontally scalable architecture that lends itself well to containerization.
 
+
 One-step setup
 ==============
 
@@ -28,6 +29,7 @@ Spin up the official `CrateDB Docker image`_, like so:
 .. TIP::
 
    If this command aborts with an error, consult the `troubleshooting guide`_.
+
 
 Next steps
 ==========

--- a/docs/install-run/index.rst
+++ b/docs/install-run/index.rst
@@ -17,13 +17,3 @@ Get up and running with CrateDB on your personal computer.
    macos
    windows
    docker
-
-.. TIP::
-
-   For production environments, you can learn more about `deploying`_ and
-   `scaling`_ CrateDB in the `CrateDB Guide`_.
-
-
-.. _CrateDB Guide: https://crate.io/docs/crate/guide/en/latest/
-.. _deploying: https://crate.io/docs/crate/guide/en/latest/deployment/index.html
-.. _scaling: https://crate.io/docs/crate/guide/en/latest/scaling/index.html

--- a/docs/install-run/linux.rst
+++ b/docs/install-run/linux.rst
@@ -6,21 +6,21 @@ Quick Install on Linux
 
 .. CAUTION::
 
-   These instructions are designed to get you quickly up and running on your local
-   computer. For putting CrateDB into production, you can learn more about
-   `deploying`_ or `scaling`_ CrateDB in the `CrateDB Guide`_.
+   These instructions are designed to get you quickly up and running on your
+   local computer. For putting CrateDB into production, check out the `How-To
+   Guides`_.
 
 .. SEEALSO::
 
-   CrateDB also maintains packages for `Debian GNU/Linux`_, `Ubuntu`_, and `RedHat
-   Linux`_.
+   CrateDB also maintains packages for `Debian GNU/Linux`_, `Ubuntu`_, and
+   `RedHat Linux`_.
 
 
 One-step setup
 ==============
 
-You can download and run CrateDB on many Linux distributions with one
-simple command in your terminal application:
+You can download and run CrateDB on many Linux distributions with one simple
+command in your terminal application:
 
 .. code-block:: console
 
@@ -34,10 +34,8 @@ Now you have CrateDB up and running, :ref:`take the guided tour <first-use>`.
 
 
 .. _bootstrap checks: https://crate.io/docs/crate/guide/en/latest/admin/bootstrap-checks.html
-.. _CrateDB Guide: https://crate.io/docs/crate/guide/en/latest/
+.. _How-To Guides: https://crate.io/docs/crate/howtos/en/latest/
 .. _Debian GNU/Linux: https://crate.io/docs/crate/guide/en/latest/deployment/linux/debian.html
-.. _deploying: https://crate.io/docs/crate/guide/en/latest/deployment/index.html
 .. _OpenJDK: https://openjdk.java.net/projects/jdk8/
 .. _RedHat Linux: https://crate.io/docs/crate/guide/en/latest/deployment/linux/red-hat.html
-.. _scaling: https://crate.io/docs/crate/guide/en/latest/scaling/index.html
 .. _Ubuntu: https://crate.io/docs/crate/guide/en/latest/deployment/linux/ubuntu.html

--- a/docs/install-run/macos.rst
+++ b/docs/install-run/macos.rst
@@ -1,26 +1,26 @@
 .. _mac-install:
 
-========================
+======================
 Quick Install on macOS
-========================
+======================
 
 .. CAUTION::
 
-   These instructions are designed to get you quickly up and running on your local
-   computer. For putting CrateDB into production, you can learn more about
-   `deploying`_ or `scaling`_ CrateDB in the `CrateDB Guide`_.
+   These instructions are designed to get you quickly up and running on your
+   local computer. For putting CrateDB into production, check out the `How-To
+   Guides`_.
 
 
 One-step setup
 ==============
 
-Because CrateDB is a Java application, it runs effortlessly on macOS. You can install and run CrateDB on macOS with one simple command in your
-terminal application:
+Because CrateDB is a Java application, it runs effortlessly on macOS. You can
+install and run CrateDB on macOS with one simple command in your terminal
+application:
 
 .. code-block:: console
 
    sh$ bash -c "$(curl -L https://try.crate.io/)"
-
 
 
 Next steps
@@ -30,8 +30,6 @@ Now you have CrateDB up and running, :ref:`take the guided tour <first-use>`.
 
 
 .. _bootstrap checks: https://crate.io/docs/crate/guide/en/latest/admin/bootstrap-checks.html
-.. _CrateDB Guide: https://crate.io/docs/crate/guide/en/latest/
-.. _deploying: https://crate.io/docs/crate/guide/en/latest/deployment/index.html
+.. _How-To Guides: https://crate.io/docs/crate/howtos/en/latest/
 .. _Java 11: https://www.oracle.com/technetwork/java/javase/downloads/index.html
 .. _Oracle's Java: https://www.java.com/en/download/help/mac_install.xml
-.. _scaling: https://crate.io/docs/crate/guide/en/latest/scaling/index.html

--- a/docs/install-run/windows.rst
+++ b/docs/install-run/windows.rst
@@ -1,27 +1,31 @@
 .. _windows-install:
 
-====================================
+========================
 Quick Install on Windows
-====================================
+========================
 
 .. CAUTION::
 
-   These instructions are designed to get you quickly up and running on your local
-   computer. For putting CrateDB into production, you can learn more about
-   `deploying`_ or `scaling`_ CrateDB in the `CrateDB Guide`_.
+   These instructions are designed to get you quickly up and running on your
+   local computer. For putting CrateDB into production, check out the `How-To
+   Guides`_.
+
 
 Prerequisites
 =============
+
 Because CrateDB is a Java application, it runs effortlessly on Microsoft
 Windows.
 
-.. NOTE::
 
-   CrateDB versions 4.2 and above include a JVM and do not require a separate
-   installation. Skip to :ref:`Download and run`
+CrateDB versions 4.2 and above include a JVM and do not require a separate
+installation. For earlier versions,  CrateDB requires a `Java virtual machine`_
+to run. Versions from 3.0 to 4.1 require a `Java 11`_ installation. We
+recommend using `Oracle's Java`_ on Microsoft Windows. Earlier versions
+required Java 8.
 
-CrateDB requires a `Java virtual machine`_ to run. Versions from 3.0 to 4.1 require a `Java 11`_ installation. We recommend
-using `Oracle's Java`_ on Microsoft Windows. Earlier versions required Java 8.
+If you are installing on `Windows Server`_, you must install the the `Microsoft
+Visual C++ 2019 Redistributable`_ package.
 
 
 .. _Download and run:
@@ -35,11 +39,12 @@ Installation <basic-install>` instructions for use with Windows
 
 1. Download `the latest CrateDB release`_.
 2. Once downloaded, expand the tarball using a tool like `7-Zip`_.
-3. `Start PowerShell`_, `change into the expanded tarball folder`_, and start CrateDB, like so:
+3. `Start PowerShell`_
+4. `Change into the expanded tarball folder`_, and start CrateDB, like so:
 
-.. code-block:: doscon
+   .. code-block:: doscon
 
-   PS> ./bin/crate
+       PS> ./bin/crate
 
 
 Next steps
@@ -51,12 +56,12 @@ Now you have CrateDB up and running, :ref:`take the guided tour <first-use>`.
 .. _7-Zip: https://www.7-zip.org/
 .. _bootstrap checks: https://crate.io/docs/crate/guide/en/latest/admin/bootstrap-checks.html
 .. _change into the expanded tarball folder: https://docs.microsoft.com/en-us/powershell/scripting/getting-started/cookbooks/managing-current-location?view=powershell-6
-.. _CrateDB Guide: https://crate.io/docs/crate/guide/en/latest/
-.. _deploying: https://crate.io/docs/crate/guide/en/latest/deployment/index.html
+.. _How-To Guides: https://crate.io/docs/crate/howtos/en/latest/
 .. _Java 11: https://www.oracle.com/technetwork/java/javase/downloads/index.html
 .. _Java virtual machine: https://en.wikipedia.org/wiki/Java_virtual_machine
+.. _Microsoft Visual C++ 2019 Redistributable: https://www.itechtics.com/microsoft-visual-c-redistributable-versions-direct-download-links/#Microsoft_Visual_C_2019_Redistributable
 .. _Oracle's Java: https://www.oracle.com/technetwork/java/javase/downloads/index.html
 .. _PowerShell: https://docs.microsoft.com/en-us/powershell/
-.. _scaling: https://crate.io/docs/crate/guide/en/latest/scaling/index.html
 .. _Start PowerShell: https://docs.microsoft.com/en-us/powershell/scripting/setup/starting-windows-powershell?view=powershell-6
 .. _the latest CrateDB release: https://crate.io/download/
+.. _Windows Server: https://www.microsoft.com/en-us/windows-server


### PR DESCRIPTION
This changeset does the following:

- Adds a note about installing on Windows Server (per the discussion on
  https://github.com/crate/crate/issues/10516)

- Tidies up the RST for the `install-run` RST files
