### PR TITLE
Improve setup instructions for Windows

### DIFF
--- a/docs/install-run/windows.rst
+++ b/docs/install-run/windows.rst
@@ -16,18 +16,12 @@ Quick Install on Windows
 Prerequisites
 =============
 
-Because CrateDB is a Java application, it runs effortlessly on Microsoft
-Windows.
+CrateDB is a Java application and runs effortlessly on Microsoft Windows.
 
+If you are installing on a recent `Windows Server`_ edition, setting up the
+latest Microsoft Visual C++ 2019 Redistributable package is required.
 
-CrateDB versions 4.2 and above include a JVM and do not require a separate
-installation. For earlier versions,  CrateDB requires a `Java virtual machine`_
-to run. Versions from 3.0 to 4.1 require a `Java 11`_ installation. We
-recommend using `Oracle's Java`_ on Microsoft Windows. Earlier versions
-required Java 8.
-
-If you are installing on `Windows Server`_, you must install the `Microsoft
-Visual C++ 2019 Redistributable`_ package.
+You can download it at `msvcrt x86-64`_, `msvcrt x86-32`_ or `msvcrt ARM64`_.
 
 
 .. _install-windows-download-run:
@@ -35,17 +29,24 @@ Visual C++ 2019 Redistributable`_ package.
 Download and run
 ================
 
-For this specialized guide, we have adapted the :ref:`Basic tarball
-Installation <install>` instructions for use with Windows `PowerShell`_.
-
 1. Download `the latest CrateDB release`_.
-2. Once downloaded, expand the tarball using a tool like `7-Zip`_.
-3. `Start PowerShell`_
-4. `Change into the expanded tarball folder`_, and start CrateDB, like so:
+2. Once downloaded, inflate the Zip archive.
+3. `Start PowerShell`_.
+4. `Change into the extracted folder`_, and start CrateDB, like so:
 
    .. code-block:: doscon
 
        PS> ./bin/crate
+
+
+.. NOTE::
+
+    CrateDB versions 4.2 and above include a JVM and do not require a separate
+    installation. For earlier versions, CrateDB requires a `Java virtual
+    machine`_ to run. Versions from 3.0 to 4.1 require a `Java 11`_
+    installation. We recommend using `Oracle's Java`_ on Microsoft Windows.
+    Earlier versions required Java 8.
+
 
 
 .. _install-windows-next:
@@ -56,13 +57,14 @@ Next steps
 Now you have CrateDB up and running, :ref:`take the guided tour <use>`.
 
 
-.. _7-Zip: https://www.7-zip.org/
 .. _bootstrap checks: https://crate.io/docs/crate/guide/en/latest/admin/bootstrap-checks.html
-.. _change into the expanded tarball folder: https://docs.microsoft.com/en-us/powershell/scripting/getting-started/cookbooks/managing-current-location?view=powershell-6
+.. _Change into the extracted folder: https://docs.microsoft.com/en-us/powershell/scripting/getting-started/cookbooks/managing-current-location?view=powershell-6
 .. _How-To Guides: https://crate.io/docs/crate/howtos/en/latest/
 .. _Java 11: https://www.oracle.com/technetwork/java/javase/downloads/index.html
 .. _Java virtual machine: https://en.wikipedia.org/wiki/Java_virtual_machine
-.. _Microsoft Visual C++ 2019 Redistributable: https://www.itechtics.com/microsoft-visual-c-redistributable-versions-direct-download-links/#Microsoft_Visual_C_2019_Redistributable
+.. _msvcrt ARM64: https://aka.ms/vs/16/release/VC_redist.arm64.exe
+.. _msvcrt x86-32: https://aka.ms/vs/16/release/vc_redist.x86.exe
+.. _msvcrt x86-64: https://aka.ms/vs/16/release/vc_redist.x64.exe
 .. _Oracle's Java: https://www.oracle.com/technetwork/java/javase/downloads/index.html
 .. _PowerShell: https://docs.microsoft.com/en-us/powershell/
 .. _Start PowerShell: https://docs.microsoft.com/en-us/powershell/scripting/setup/starting-windows-powershell?view=powershell-6


### PR DESCRIPTION
Hi there,

this patch tries to improve and clarify the installation instructions on Windows. It might have happened that @nkev was misguided to use the distribution tarball instead of the appropriate zip archive including the bundled Java runtime. See also https://github.com/crate/crate/issues/11110.

With kind regards,
Andreas.