### PR TITLE
Improve linking to other parts of the documentation using intersphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,1 +1,17 @@
 from crate.theme.rtd.conf.crate_tutorials import *
+
+
+if "sphinx.ext.intersphinx" not in extensions:
+    extensions += ["sphinx.ext.intersphinx"]
+
+
+if "intersphinx_mapping" not in globals():
+    intersphinx_mapping = {}
+
+
+intersphinx_mapping.update({
+    'reference': ('https://crate.io/docs/crate/reference/', None),
+    'howtos': ('https://crate.io/docs/crate/howtos/', None),
+    'admin-ui': ('https://crate.io/docs/crate/admin-ui/', None),
+    'crash': ('https://crate.io/docs/crate/crash/', None),
+    })

--- a/docs/normalize-intervals.rst
+++ b/docs/normalize-intervals.rst
@@ -352,7 +352,7 @@ Above, the ``plot()`` function:
  * Activates x-axis tick label `auto-formatting`_ (rotates them for improved
    readability)
 
-.. _auto-formatting: https://matplotlib.org/stable/api/_as_gen/matplotlib.figure.Figure.html#matplotlib.figure.Figure.autofmt_xdate
+.. _auto-formatting: https://matplotlib.org/stable/api/figure_api.html#matplotlib.figure.Figure.autofmt_xdate
 
 .. SEEALSO::
 


### PR DESCRIPTION
Hi there,

this patch starts making use of [intersphinx](https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html) in order to prepare the stage for #41.

In the long run, this should happen in crate-docs-theme already. In order to provide headroom for this, the addition here is made in a graceful and forward-compatible manner.

With kind regards,
Andreas.