### PR TITLE
Improve intersphinx linking once more

### DIFF
--- a/docs/generate-time-series/node.rst
+++ b/docs/generate-time-series/node.rst
@@ -343,7 +343,6 @@ will open up a map view showing the current position of the ISS:
 .. _Client: https://node-postgres.com/api/client
 .. _connect: https://node-postgres.com/features/connecting
 .. _Connection Pool: https://node-postgres.com/api/pool
-.. _CrateDB Admin UI: https://crate.io/docs/clients/admin-ui/en/latest/
 .. _detailed guide: https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Promises
 .. _ground point: https://en.wikipedia.org/wiki/Ground_track
 .. _input values: https://node-postgres.com/features/queries#Parameterized%20query
@@ -355,5 +354,4 @@ will open up a map view showing the current position of the ISS:
 .. _open notify: http://open-notify.org/
 .. _promise chaining: https://javascript.info/promise-chaining
 .. _promises: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
-.. _SELECT: https://crate.io/docs/crate/reference/en/latest/general/dql/selects.html
 .. _WKT: https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry

--- a/docs/generate-time-series/python.rst
+++ b/docs/generate-time-series/python.rst
@@ -106,7 +106,7 @@ Then, :ref:`crate-python:connect`:
     Modify the argument if you wish to connect to a CrateDB node on a different
     host or port number.
 
-Get a `cursor`_:
+Get a :ref:`cursor <crate-python:cursor>`:
 
     >>>  cursor = connection.cursor()
 
@@ -143,7 +143,7 @@ back out of CrateDB.
 
     >>> cursor.execute('SELECT * FROM iss ORDER BY timestamp DESC')
 
-Then, `fetch all`_ the result rows at once:
+Then, :ref:`fetch all <crate-python:fetchall>` the result rows at once:
 
     >>> cursor.fetchall()
     [[1582295967721, [-8.0689, 25.8967]],
@@ -237,8 +237,6 @@ will open up a map view showing the current position of the ISS:
     zooming out.
 
 
-.. _cursor: https://crate.io/docs/python/en/latest/query.html#using-a-cursor
-.. _fetch all: https://crate.io/docs/python/en/latest/query.html#fetchmany
 .. _ground point: https://en.wikipedia.org/wiki/Ground_track
 .. _interactive mode: https://docs.python.org/3/tutorial/interpreter.html#interactive-mode
 .. _International Space Station: https://www.nasa.gov/mission_pages/station/main/index.html

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -195,10 +195,10 @@ official `CrateDB Docker image`_, use::
 
 .. TIP::
 
-    If this command aborts with an error, please consult the `Docker
-    troubleshooting guide`_. You are also welcome learn more about
-    :ref:`howtos:resource_constraints` with respect to running CrateDB within
-    containers.
+    If this command aborts with an error, please consult the :ref:`Docker
+    troubleshooting guide <howtos:docker-troubleshooting>`. You are also
+    welcome learn more about :ref:`howtos:resource_constraints` with respect
+    to running CrateDB within containers.
 
 .. CAUTION::
 
@@ -326,10 +326,8 @@ quickly adjust the :ref:`configuration settings <install-configure>`, read more
 details about the :ref:`reference:config` of CrateDB, the background about
 :ref:`howtos:bootstrap-checks`, multi-node configuration within the section
 about :ref:`howtos:clustering` and :ref:`howtos:going-into-production`. When
-operating a CrateDB cluster in production, `performance tuning`_ will also be
-of interest.
-
-.. _performance tuning: https://crate.io/docs/crate/howtos/en/latest/performance/
+operating a CrateDB cluster in production, :ref:`performance tuning
+<howtos:performance>` will also be of interest.
 
 .. NOTE::
 
@@ -348,7 +346,6 @@ of interest.
 .. _CrateDB release archive: https://crate.io/download/
 .. _deb: https://en.wikipedia.org/wiki/Deb_(file_format)
 .. _Docker: https://www.docker.com/
-.. _Docker troubleshooting guide: https://crate.io/docs/crate/howtos/en/latest/deployment/containers/docker.html#troubleshooting
 .. _Java virtual machine: https://en.wikipedia.org/wiki/Java_virtual_machine
 .. _msvcrt ARM64: https://aka.ms/vs/16/release/VC_redist.arm64.exe
 .. _msvcrt x86-32: https://aka.ms/vs/16/release/vc_redist.x86.exe

--- a/docs/normalize-intervals.rst
+++ b/docs/normalize-intervals.rst
@@ -540,7 +540,7 @@ null values filling in for missing data.
 
 .. SEEALSO::
 
-    Read more about `how joins work`_.
+    Read more about :ref:`how joins work <reference:concept-joins>`.
 
 
 .. _ni-brief-example:
@@ -787,7 +787,6 @@ This visualization resolves both original issues:
 
 .. _data binning: https://en.wikipedia.org/wiki/Data_binning
 .. _ground point: https://en.wikipedia.org/wiki/Ground_track
-.. _how joins work: https://crate.io/docs/crate/reference/en/latest/concepts/joins.html
 .. _interactive mode: https://docs.python.org/3/tutorial/interpreter.html#interactive-mode
 .. _International Space Station: https://www.nasa.gov/mission_pages/station/main/index.html
 .. _Internet of Things: https://en.wikipedia.org/wiki/Internet_of_things

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
+sphinx==3.5.3
 crate-docs-theme


### PR DESCRIPTION
As a followup to #48, this improves the linking once more. However, this patch needs some upstream projects to integrate the corresponding patches there beforehand.

- https://github.com/crate/crate-howtos/pull/275
- https://github.com/crate/crate-python/pull/407
- https://github.com/crate/crate/pull/11206
