### PR TITLE
Explicitly use docutils==0.16

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
-sphinx==3.5.3
+sphinx==3.5.4
+docutils==0.16
 crate-docs-theme


### PR DESCRIPTION
Hi,

until we've updated the CSS stylesheets to honor the improvements coming in from docutils==0.17 (see https://github.com/crate/crate-docs-theme/issues/252), we should be using docutils==0.16 explicitly.

With kind regards,
Andreas.
