### PR TITLE
Appropriately reintroduce "Try CrateDB without installing" section

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -216,8 +216,8 @@ official `CrateDB Docker image`_, use::
 
 .. _install-adhoc:
 
-Ad-hoc (Unix, Windows)
-======================
+Ad-hoc (Unix, macOS, Windows)
+=============================
 
 This section of the documentation outlines how to use the release archives to
 install CrateDB. The walkthrough is suitable to install and run CrateDB on both
@@ -271,6 +271,16 @@ will look like this.
 
     PS> ./bin/crate
 
+
+Notes about Linux and macOS
+---------------------------
+
+You can also install and run CrateDB on Linux and macOS with one simple command
+in your terminal application:
+
+.. code-block:: console
+
+   sh$ bash -c "$(curl -L https://try.crate.io/)"
 
 
 .. _install-configure:
@@ -350,7 +360,7 @@ operating a CrateDB cluster in production, :ref:`performance tuning
 .. _apt: https://en.wikipedia.org/wiki/APT_(software)
 .. _contact us: https://crate.io/contact/
 .. _CrateDB Docker image: https://hub.docker.com/_/crate/
-.. _CrateDB release archive: https://crate.io/download/
+.. _CrateDB release archive: https://cdn.crate.io/downloads/releases/cratedb/
 .. _deb: https://en.wikipedia.org/wiki/Deb_(file_format)
 .. _Docker: https://www.docker.com/
 .. _Java virtual machine: https://en.wikipedia.org/wiki/Java_virtual_machine

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -49,6 +49,28 @@ After successfully installing CrateDB, please also consider reading the
       and `Oracle Java`_ on Microsoft Windows and macOS.
 
 
+.. _install-quick:
+
+Try CrateDB without installing
+==============================
+
+If you want to try out CrateDB on Linux or macOS but would prefer to avoid the
+hassle of manual installation or extracting release archives, you can get a
+fresh CrateDB node up and running in your current working directory with a
+single command:
+
+.. code-block:: console
+
+   sh$ bash -c "$(curl -L https://try.crate.io/)"
+
+
+.. NOTE::
+
+    This is a quick way to *try out* CrateDB. It is not the recommended method
+    to *install* CrateDB in a durable way. The following sections will outline
+    that method.
+
+
 .. _install-linux:
 
 Linux
@@ -270,18 +292,6 @@ will look like this.
 .. code-block:: doscon
 
     PS> ./bin/crate
-
-
-Notes about Linux and macOS
----------------------------
-
-If you want to try out CrateDB but would prefer to avoid the hassle of
-installation, you can get a fresh CrateDB node up and running in your current
-working directory with a single command:
-
-.. code-block:: console
-
-   sh$ bash -c "$(curl -L https://try.crate.io/)"
 
 
 .. _install-configure:

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -275,8 +275,9 @@ will look like this.
 Notes about Linux and macOS
 ---------------------------
 
-You can also install and run CrateDB on Linux and macOS with one simple command
-in your terminal application:
+If you want to try out CrateDB but would prefer to avoid the hassle of
+installation, you can get a fresh CrateDB node up and running in your current
+working directory with a single command:
 
 .. code-block:: console
 


### PR DESCRIPTION
Hi Georg and Naomi,

based on our recent discussion, this brings back installation instructions for macOS in form of a refurbished "Try CrateDB without installing" section.

With kind regards,
Andreas.
