### PR TITLE
Update invalid references

### DIFF
--- a/docs/create-sharded-table.rst
+++ b/docs/create-sharded-table.rst
@@ -9,7 +9,7 @@ One core concept CrateDB uses to distribute data across a cluster is
 configured number of shards, which are distributed evenly across the cluster. 
 You can think of shards as a self-contained part of a table, that includes both 
 a subset of records and corresponding indexing structures. If we 
-:ref:`create a table <crate-reference:sql_ddl_create>` like the following:
+:ref:`create a table <crate-reference:ddl-create-table>` like the following:
 
 .. code-block:: psql
 

--- a/docs/generate-time-series/cli.rst
+++ b/docs/generate-time-series/cli.rst
@@ -153,7 +153,7 @@ Start an interactive Crash session:
     Modify the argument if you wish to connect to a CrateDB node on a different
     host or port number.
 
-Then, :ref:`create a table <crate-reference:sql_ddl_create>` suitable for writing
+Then, :ref:`create a table <crate-reference:ddl-create-table>` suitable for writing
 load averages.
 
 .. code-block:: psql
@@ -181,7 +181,7 @@ statements directly from the command line.
 
 First, exit from the interactive Crash session (or open a new terminal). Then,
 use ``crash`` with the ``--command`` argument to execute an :ref:`INSERT
-<crate-reference:inserting_data>` query.
+<crate-reference:dml-inserting-data>` query.
 
 .. code-block:: console
 

--- a/docs/generate-time-series/go.rst
+++ b/docs/generate-time-series/go.rst
@@ -232,7 +232,7 @@ client:
 
 Then, in your main function, connect to CrateDB using the
 :ref:`crate-reference:postgres_wire_protocol` port (``5432``) and
-:ref:`create a table <crate-reference:sql_ddl_create>` suitable for writing ISS
+:ref:`create a table <crate-reference:ddl-create-table>` suitable for writing ISS
 position coordinates.
 
 .. code-block:: go
@@ -277,7 +277,7 @@ Record the ISS position
 With the table in place, you can start recording the position of the ISS.
 
 Create some logic that calls your ``getISSPosition`` function and :ref:`insert
-<crate-reference:inserting_data>` the result into the ``iss`` table.
+<crate-reference:dml-inserting-data>` the result into the ``iss`` table.
 
 .. code-block:: go
 

--- a/docs/generate-time-series/node.rst
+++ b/docs/generate-time-series/node.rst
@@ -129,7 +129,7 @@ Then `connect`_ to CrateDB, using the :ref:`crate-reference:postgres_wire_protoc
 
     > await client.connect()
 
-Finally, :ref:`create a table <crate-reference:sql_ddl_create>` suitable for writing
+Finally, :ref:`create a table <crate-reference:ddl-create-table>` suitable for writing
 ISS position coordinates.
 
 .. code-block:: js
@@ -180,7 +180,7 @@ Record the ISS position
 With the table in place, you can start recording the position of the ISS.
 
 The following command calls your ``position`` function and will :ref:`insert
-<crate-reference:inserting_data>` the result into the ``iss`` table.
+<crate-reference:dml-inserting-data>` the result into the ``iss`` table.
 
 .. code-block:: js
 

--- a/docs/generate-time-series/python.rst
+++ b/docs/generate-time-series/python.rst
@@ -110,7 +110,7 @@ Get a :ref:`cursor <crate-python:cursor>`:
 
     >>>  cursor = connection.cursor()
 
-Finally, :ref:`create a table <crate-reference:sql_ddl_create>` suitable for writing
+Finally, :ref:`create a table <crate-reference:ddl-create-table>` suitable for writing
 ISS position coordinates.
 
     >>> cursor.execute(
@@ -131,7 +131,7 @@ Record the ISS position
 With the table in place, you can start recording the position of the ISS.
 
 The following command calls your ``position`` function and will :ref:`insert
-<crate-reference:inserting_data>` the result into the ``iss`` table:
+<crate-reference:dml-inserting-data>` the result into the ``iss`` table:
 
     >>> cursor.execute("INSERT INTO iss (position) VALUES (?)", [position()])
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Fix a few broken references to `crate-reference` so that `make check` passes again.

## Checklist

 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
