### PR TITLE
Use date_bin instead of date_trunc in time series tutorial

### DIFF
--- a/docs/generate-time-series/go.rst
+++ b/docs/generate-time-series/go.rst
@@ -135,7 +135,7 @@ keys which don't have a corresponding struct field are ignored.
 
 Now, create a function that makes an HTTP GET request to the Open Notify API
 endpoint and returns longitude and latitude as a
-:ref:`crate-reference:geo_point_data_type` declaration.
+:ref:`crate-reference:data-types-geo` declaration.
 
 .. code-block:: go
 
@@ -231,7 +231,7 @@ client:
     )
 
 Then, in your main function, connect to CrateDB using the
-:ref:`crate-reference:postgres_wire_protocol` port (``5432``) and
+:ref:`crate-reference:interface-postgresql` port (``5432``) and
 :ref:`create a table <crate-reference:ddl-create-table>` suitable for writing ISS
 position coordinates.
 

--- a/docs/generate-time-series/node.rst
+++ b/docs/generate-time-series/node.rst
@@ -118,7 +118,7 @@ First, import the `node-postgres`_ client:
 
     > const { Client } = require('pg')
 
-Then `connect`_ to CrateDB, using the :ref:`crate-reference:postgres_wire_protocol` port
+Then `connect`_ to CrateDB, using the :ref:`crate-reference:interface-postgresql` port
 (``5432``):
 
 .. code-block:: js

--- a/docs/normalize-intervals.rst
+++ b/docs/normalize-intervals.rst
@@ -228,9 +228,9 @@ Here are a few ways to improve this result:
  * The ``timestamp`` column isn't human-readable. It would be easier to
    understand the results if this value was as a human-readable time.
 
- * The ``position`` column is a :ref:`crate-reference:geo_point_data_type`. This data
+ * The ``position`` column is a :ref:`crate-reference:data-types-geo`. This data
    type isn't easy to plot on a traditional graph. However, you can use the
-   :ref:`distance() <crate-reference:scalar_distance>` function to calculate the
+   :ref:`distance() <crate-reference:scalar-distance>` function to calculate the
    distance between two ``geo_point`` values. If you compare ``position`` to a
    fixed place, you can plot distance over time for a graph showing you how far
    away the ISS is from some location of interest.
@@ -262,7 +262,7 @@ Specifically:
  * You can define the `location`_ of Berlin and interpolate that into the query
    to calculate the ``DISTANCE()`` of the ISS ground point in kilometers.
 
- * You can use :ref:`CURRENT_TIMESTAMP <crate-reference:current_timestamp>` with an
+ * You can use :ref:`CURRENT_TIMESTAMP <crate-reference:scalar-current_timestamp>` with an
    interval :ref:`value expression <crate-reference:sql-value-expressions>`
    (``INTERVAL '1' DAY``) to calculate a timestamp that is 24 hours in the
    past. You can then use a :ref:`WHERE clause <crate-reference:sql-select-where>`
@@ -399,7 +399,7 @@ high, creating an unnecessary large number of data points. Therefore, here is a
 basic approach to resample data at a lower frequency:
 
  1. Place values of the ``time`` column into bins for a given interval (using
-    :ref:`DATE_BIN() <crate-reference:date_bin>`).
+    :ref:`DATE_BIN() <crate-reference:date-bin>`).
 
     In this example, we are resampling the data per minute. This means that all
     rows with an identical ``time`` value on minute-level are placed into the


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Make use of the new `DATE_BIN` in favor of `DATE_TRUNC`. The ISS example doesn't allow making use of the full flexibility of `DATE_BIN`, we will have to come up with a more suitable example separately.

Also intentionally decided against adding additional interpolation methods enabled by CrateDB 4.7 (`IGNORE NULLS`), as Last Observation Carried Forward doesn't really make much sense for the ISS, as it's moving permanently. A rolling average would make more sense, but for my taste, the article is already way too lengthy/verbose.

## Checklist

 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
