### PR TITLE
Improve installation instructions on Debian multiarch systems

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -102,7 +102,7 @@ the CrateDB package repository::
     [[ $(lsb_release --id --short) = "Debian" ]] && repository="apt"
     [[ $(lsb_release --id --short) = "Ubuntu" ]] && repository="deb"
     distribution=$(lsb_release --codename --short)
-    sudo add-apt-repository "deb https://cdn.crate.io/downloads/${repository}/stable/ ${distribution} main"
+    sudo add-apt-repository "deb [arch=amd64] https://cdn.crate.io/downloads/${repository}/stable/ ${distribution} main"
 
 
 .. NOTE::


### PR DESCRIPTION
Hi there,

@msbt reported a flaw with the installation on Debian multiarch systems at https://github.com/crate/crate/issues/11701.

By specifically adding [arch=amd64] in the sources link, the installation can be fixed on multiarch systems. Otherwise, adding the package repository "croaks" with "repository doesn't support architecture 'i386'".

With kind regards,
Andreas.
