### PR TITLE
Fix broken references

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -86,7 +86,7 @@ SRC_MAKE      := $(MAKE) -f $(SRC_DIR)/rules.mk
 
 # Parse the JSON file
 BUILD_VERSION := $(shell cat $(BUILD_JSON) | \
-    python -c 'import json, sys; print(json.load(sys.stdin)["message"])')
+    python3 -c 'import json, sys; print(json.load(sys.stdin)["message"])')
 
 ifeq ($(BUILD_VERSION),)
 $(error No build version specified in `$(BUILD_JSON)`.)

--- a/docs/basic/index.rst
+++ b/docs/basic/index.rst
@@ -228,8 +228,8 @@ official `CrateDB Docker image`_, use::
 .. TIP::
 
     If this command aborts with an error, please consult the :ref:`Docker
-    troubleshooting guide <crate-howtos:docker-troubleshooting>`. You are also
-    welcome learn more about :ref:`crate-howtos:resource_constraints` with respect
+    troubleshooting guide <docker-troubleshooting>`. You are also
+    welcome learn more about :ref:`resource_constraints` with respect
     to running CrateDB within containers.
 
 .. CAUTION::
@@ -241,7 +241,7 @@ official `CrateDB Docker image`_, use::
     container, all data will be lost.
 
     When you are ready to start using CrateDB for data you care about, please
-    consult the :ref:`full guide to CrateDB and Docker <crate-howtos:cratedb-docker>`
+    consult the :ref:`full guide to CrateDB and Docker <cratedb-docker>`
     in order to configure the Docker setup appropriately by using persistent
     disk volumes.
 

--- a/docs/build.json
+++ b/docs/build.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
   "label": "docs build",
-  "message": "2.0.0"
+  "message": "2.0.2"
 }


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

After the recent restructuring (#77), some references weren't valid anymore. It couldn't be noticed on the productive documentation deployment as redirects are in place, still catching the old URLs, but `make check` in this repository is failing.

## Checklist

 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
