### PR TITLE
Replace deprecated `recover_after_nodes`/`expected_nodes` settings

### DIFF
--- a/docs/containers/docker.rst
+++ b/docs/containers/docker.rst
@@ -74,7 +74,8 @@ You can then create your first CrateDB container and node, like this::
                 -Cnode.name=crate01 \
                 -Cdiscovery.seed_hosts=crate02,crate03 \
                 -Ccluster.initial_master_nodes=crate01,crate02 \
-                -Cgateway.expected_nodes=3  -Cgateway.recover_after_nodes=3
+                -Cgateway.expected_data_nodes=3 \
+                -Cgateway.recover_after_data_nodes=3
 
 Breaking the command down:
 
@@ -105,9 +106,9 @@ Breaking the command down:
       (first bootstrap). If this parameter is not defined, then it is expected
       that the node will join an already formed cluster. This parameter is only
       relevant for the first election.
-    * ``gateway.expected_nodes`` and ``gateway.recover_after_nodes``: Specifies
-      how many nodes you expect in the cluster and how many nodes must be
-      discovered before the cluster state is recovered.
+    * ``gateway.expected_data_nodes`` and ``gateway.recover_after_data_nodes``:
+      Specifies how many nodes you expect in the cluster and how many nodes must
+      be discovered before the cluster state is recovered.
 
 .. NOTE::
 
@@ -152,7 +153,8 @@ Now add the second node, ``crate02``, to the cluster::
                 -Cnode.name=crate02 \
                 -Cdiscovery.seed_hosts=crate01,crate03 \
                 -Ccluster.initial_master_nodes=crate01,crate02 \
-                -Cgateway.expected_nodes=3 -Cgateway.recover_after_nodes=2
+                -Cgateway.expected_data_nodes=3 \
+                -Cgateway.recover_after_data_nodes=2
 
 Notice here that:
 
@@ -177,7 +179,8 @@ You can now add ``crate03`` like this::
           crate -Cnetwork.host=_site_ \
                 -Cnode.name=crate03 \
                 -Cdiscovery.seed_hosts=crate01,crate02 \
-                -Cgateway.expected_nodes=3 -Cgateway.recover_after_nodes=2
+                -Cgateway.expected_data_nodes=3 \
+                -Cgateway.recover_after_data_nodes=2
 
 Notice here that:
 
@@ -292,8 +295,8 @@ define your services like this:
                   "-Cnetwork.host=_site_",
                   "-Cdiscovery.seed_hosts=cratedb02,cratedb03",
                   "-Ccluster.initial_master_nodes=cratedb01,cratedb02,cratedb03",
-                  "-Cgateway.expected_nodes=3",
-                  "-Cgateway.recover_after_nodes=2"]
+                  "-Cgateway.expected_data_nodes=3",
+                  "-Cgateway.recover_after_data_nodes=2"]
         deploy:
           replicas: 1
           restart_policy:
@@ -314,8 +317,8 @@ define your services like this:
                   "-Cnetwork.host=_site_",
                   "-Cdiscovery.seed_hosts=cratedb01,cratedb03",
                   "-Ccluster.initial_master_nodes=cratedb01,cratedb02,cratedb03",
-                  "-Cgateway.expected_nodes=3",
-                  "-Cgateway.recover_after_nodes=2"]
+                  "-Cgateway.expected_data_nodes=3",
+                  "-Cgateway.recover_after_data_nodes=2"]
         deploy:
           replicas: 1
           restart_policy:
@@ -336,8 +339,8 @@ define your services like this:
                   "-Cnetwork.host=_site_",
                   "-Cdiscovery.seed_hosts=cratedb01,cratedb02",
                   "-Ccluster.initial_master_nodes=cratedb01,cratedb02,cratedb03",
-                  "-Cgateway.expected_nodes=3",
-                  "-Cgateway.recover_after_nodes=2"]
+                  "-Cgateway.expected_data_nodes=3",
+                  "-Cgateway.recover_after_data_nodes=2"]
         deploy:
           replicas: 1
           restart_policy:

--- a/docs/containers/kubernetes.rst
+++ b/docs/containers/kubernetes.rst
@@ -259,8 +259,8 @@ CrateDB 3.0.5 cluster:
               - -Ccluster.initial_master_nodes=crate-0,crate-1,crate-2
               - -Cdiscovery.seed_providers=srv
               - -Cdiscovery.srv.query=_crate-internal._tcp.crate-internal-service.${NAMESPACE}.svc.cluster.local
-              - -Cgateway.recover_after_nodes=2
-              - -Cgateway.expected_nodes=${EXPECTED_NODES}
+              - -Cgateway.recover_after_data_nodes=2
+              - -Cgateway.expected_data_nodes=${EXPECTED_NODES}
               - -Cpath.data=/data
             volumeMounts:
                   # Mount the `/data` directory as a volume named `data`.


### PR DESCRIPTION
… with `gateway.recover_after_data_nodes`/`gateway.expected_data_nodes`

See also https://github.com/crate/crate-howtos/pull/309.

## Summary of the changes / Why this is an improvement
Fixes deprecation warnings during node startup.

## Checklist

 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
