### PR TITLE
Update kubernetes.rst

### DIFF
--- a/docs/containers/kubernetes/kubernetes.rst
+++ b/docs/containers/kubernetes/kubernetes.rst
@@ -191,7 +191,7 @@ For this reason, we use the `StatefulSet`_ controller to define our cluster,
 which ensures that CrateDB nodes retain state across restarts or rescheduling.
 
 The following configuration snippet defines a controller for a three-node
-CrateDB 3.0.5 cluster:
+CrateDB 5.0.3 cluster:
 
 .. code-block:: yaml
 
@@ -228,8 +228,8 @@ CrateDB 3.0.5 cluster:
           # It defines the container to run in each pod.
           containers:
           - name: crate
-            # Use the CrateDB 4.2.4 Docker image.
-            image: crate:4.2.4
+            # Use the CrateDB 5.0.3 Docker image.
+            image: crate: 5.0.3
             # Pass in configuration to CrateDB via command-line options.
             # We are setting the name of the node's explicitly, which is
             # needed to determine the initial master nodes. These are set to
@@ -295,7 +295,7 @@ CrateDB 3.0.5 cluster:
 
 .. CAUTION::
 
-   If you are not running CrateDB 3.0.5, you must adapt this example
+   If you are not running CrateDB 5.0.3, you must adapt this example
    configuration to your specific CrateDB version.
 
    Specifically, the ``discovery.zen.minimum_master_nodes`` setting is :ref:`no

--- a/docs/containers/kubernetes/kubernetes.rst
+++ b/docs/containers/kubernetes/kubernetes.rst
@@ -229,7 +229,7 @@ CrateDB 5.1.1 cluster:
           containers:
           - name: crate
             # Use the CrateDB 5.1.1 Docker image.
-            image: crate: 5.1.1
+            image: crate:5.1.1
             # Pass in configuration to CrateDB via command-line options.
             # We are setting the name of the node's explicitly, which is
             # needed to determine the initial master nodes. These are set to

--- a/docs/containers/kubernetes/kubernetes.rst
+++ b/docs/containers/kubernetes/kubernetes.rst
@@ -191,7 +191,7 @@ For this reason, we use the `StatefulSet`_ controller to define our cluster,
 which ensures that CrateDB nodes retain state across restarts or rescheduling.
 
 The following configuration snippet defines a controller for a three-node
-CrateDB 5.0.3 cluster:
+CrateDB 5.1.1 cluster:
 
 .. code-block:: yaml
 
@@ -228,8 +228,8 @@ CrateDB 5.0.3 cluster:
           # It defines the container to run in each pod.
           containers:
           - name: crate
-            # Use the CrateDB 5.0.3 Docker image.
-            image: crate: 5.0.3
+            # Use the CrateDB 5.1.1 Docker image.
+            image: crate: 5.1.1
             # Pass in configuration to CrateDB via command-line options.
             # We are setting the name of the node's explicitly, which is
             # needed to determine the initial master nodes. These are set to
@@ -295,7 +295,7 @@ CrateDB 5.0.3 cluster:
 
 .. CAUTION::
 
-   If you are not running CrateDB 5.0.3, you must adapt this example
+   If you are not running CrateDB 5.1.1, you must adapt this example
    configuration to your specific CrateDB version.
 
    Specifically, the ``discovery.zen.minimum_master_nodes`` setting is :ref:`no


### PR DESCRIPTION
edited the CrateDB version mentioned here which was not uniform. Replaced all version references for 5.0.3

## Summary of the changes / Why this is an improvement
Previously the versions mentioned here were not uniform, some places said 3.0.5 others had 4.1.2. Replaced them all for 5.0.3.

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
