### PR TITLE
Rename allow_mmapfs to allow_mmap in Docker tutorial

### DIFF
--- a/docs/containers/docker.rst
+++ b/docs/containers/docker.rst
@@ -213,13 +213,13 @@ The most common issue when running CrateDB on Docker is a failing
 is too low. This can be :ref:`adjusted on the host system <bootstrap-checks>`.
 
 If the limit cannot be adjusted on the host system, the memory map limit check
-can be bypassed by passing the ``-Cnode.store.allow_mmapfs=false`` option to
+can be bypassed by passing the ``-Cnode.store.allow_mmap=false`` option to
 the ``crate`` command::
 
     sh$ docker run -d --name=crate01 \
           --net=crate -p 4201:4200 --env CRATE_HEAP_SIZE=2g \
           crate -Cnetwork.host=_site_ \
-                -Cnode.store.allow_mmapfs=false
+                -Cnode.store.allow_mmap=false
 
 .. CAUTION::
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

`node.store.allow_mmapfs` was deprecated in 4.1.0 and is not currently working on 5.1.1, `node.store.allow_mmap` achieves the same objective.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
