### PR TITLE
Remove obsolete reference in Kubernetes tutorial

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
 

--- a/docs/containers/kubernetes/kubernetes.rst
+++ b/docs/containers/kubernetes/kubernetes.rst
@@ -298,9 +298,6 @@ CrateDB 5.1.1 cluster:
    If you are not running CrateDB 5.1.1, you must adapt this example
    configuration to your specific CrateDB version.
 
-   Specifically, the ``discovery.zen.minimum_master_nodes`` setting is :ref:`no
-   longer used <node-discovery>` in CrateDB versions 4.x and above.
-
 .. SEEALSO::
 
    CrateDB supports `configuration via command-line options`_ and `node


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
The reference to `discovery.zen.minimum_master_nodes` appears out of place as it is nowhere mentioned on that page.

## Checklist

 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
