### PR TITLE
Docker: Improve `docker run` instruction by adding `--pull=always`

### DIFF
--- a/docs/basic/index.rst
+++ b/docs/basic/index.rst
@@ -212,7 +212,7 @@ horizontally scalable architecture that lends itself well to containerization.
 In order to spin up a container using the most recent stable version of the
 official `CrateDB Docker image`_, use::
 
-    docker run --publish=4200:4200 --publish=5432:5432 crate
+    docker run --publish=4200:4200 --publish=5432:5432 --pull=always crate
 
 .. TIP::
 


### PR DESCRIPTION
Discovered by @marijaselakovic, this adjustment improves the running-on-Docker experience a bit, for people copying the instructions 1:1. Thanks!