### PR TITLE
Debian/Ubuntu: Modernize installation instructions

### DIFF
--- a/docs/basic/index.rst
+++ b/docs/basic/index.rst
@@ -91,17 +91,21 @@ You will need to configure your system to register with and trust packages from
 the CrateDB package repository::
 
     # Install prerequisites.
-    apt-get install sudo
-    sudo apt-get install curl gnupg software-properties-common apt-transport-https apt-utils
+    apt update
+    apt install --yes sudo
+    sudo apt install --yes apt-transport-https apt-utils curl gnupg lsb-release
 
     # Import the public GPG key for verifying the package signatures.
-    curl -sS https://cdn.crate.io/downloads/deb/DEB-GPG-KEY-crate | sudo apt-key add -
+    sudo curl -sS https://cdn.crate.io/downloads/deb/DEB-GPG-KEY-crate > /etc/apt/trusted.gpg.d/cratedb.asc
 
-    # Register with the CrateDB package repository.
+    # Compute CrateDB package repository location.
     [[ $(lsb_release --id --short) = "Debian" ]] && repository="apt"
     [[ $(lsb_release --id --short) = "Ubuntu" ]] && repository="deb"
     distribution=$(lsb_release --codename --short)
-    sudo add-apt-repository "deb [arch=amd64] https://cdn.crate.io/downloads/${repository}/stable/ ${distribution} main"
+
+    # Register with the CrateDB package repository.
+    sudo echo "deb [signed-by=/etc/apt/trusted.gpg.d/cratedb.asc arch=amd64] https://cdn.crate.io/downloads/${repository}/stable/ ${distribution} main" \
+        > /etc/apt/sources.list.d/cratedb.list
 
 
 .. NOTE::

--- a/docs/basic/index.rst
+++ b/docs/basic/index.rst
@@ -95,7 +95,7 @@ the CrateDB package repository::
     sudo apt install --yes apt-transport-https apt-utils curl gnupg lsb-release
 
     # Import the public GPG key for verifying the package signatures.
-    sudo curl -sS https://cdn.crate.io/downloads/deb/DEB-GPG-KEY-crate > /etc/apt/trusted.gpg.d/cratedb.asc
+    curl -sS https://cdn.crate.io/downloads/deb/DEB-GPG-KEY-crate | sudo tee /etc/apt/trusted.gpg.d/cratedb.asc
 
     # Compute CrateDB package repository location.
     [[ $(lsb_release --id --short) = "Debian" ]] && repository="apt"
@@ -103,8 +103,8 @@ the CrateDB package repository::
     distribution=$(lsb_release --codename --short)
 
     # Register with the CrateDB package repository.
-    sudo echo "deb [signed-by=/etc/apt/trusted.gpg.d/cratedb.asc arch=amd64] https://cdn.crate.io/downloads/${repository}/stable/ ${distribution} main" \
-        > /etc/apt/sources.list.d/cratedb.list
+    echo "deb [signed-by=/etc/apt/trusted.gpg.d/cratedb.asc arch=amd64] https://cdn.crate.io/downloads/${repository}/stable/ ${distribution} main" \
+        | sudo tee /etc/apt/sources.list.d/cratedb.list
 
 .. NOTE::
 

--- a/docs/basic/index.rst
+++ b/docs/basic/index.rst
@@ -91,8 +91,7 @@ You will need to configure your system to register with and trust packages from
 the CrateDB package repository::
 
     # Install prerequisites.
-    apt update
-    apt install --yes sudo
+    sudo apt update
     sudo apt install --yes apt-transport-https apt-utils curl gnupg lsb-release
 
     # Import the public GPG key for verifying the package signatures.
@@ -107,15 +106,16 @@ the CrateDB package repository::
     sudo echo "deb [signed-by=/etc/apt/trusted.gpg.d/cratedb.asc arch=amd64] https://cdn.crate.io/downloads/${repository}/stable/ ${distribution} main" \
         > /etc/apt/sources.list.d/cratedb.list
 
-
 .. NOTE::
 
     CrateDB provides both *stable release* and *testing release* channels. To
     use the testing channel, replace ``stable`` with ``testing`` in the command
     line above. You can read more about the `release workflow`_.
 
+    The walkthrough is based on the ``sudo`` program. If it is not installed on
+    your machine, run ``apt update; apt install --yes sudo`` as a ``root`` user.
 
-Now update the package sources::
+Now, update the package sources::
 
     sudo apt update
 


### PR DESCRIPTION
### About

Modernize installation instructions for Debian/Ubuntu systems, not using the `apt-key` program any longer, because it has been deprecated. While being at it, the patch also adds the `signed-by` attribute to the package registry line.

### View

Please visit [Installation » Linux » Debian or Ubuntu](https://github.com/crate/crate-tutorials/blob/amo/improve-ubuntu-docs/docs/basic/index.rst#linux) to directly display the outcome of this change.

### Details

@proddata reported and emphasized at GH-92 what some of us may already have recognized when working on Debian- or Ubuntu-based systems.
```
Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).
```

This patch aims to fix it by adjusting the documentation accordingly, also following revised best practises for 3rd-party repositories on specifying the `signed-by` attribute to the package registry line within `/etc/apt/sources.list.d/cratedb.list`:
```
deb [signed-by=/etc/apt/trusted.gpg.d/cratedb.asc arch=amd64] https://cdn.crate.io/downloads/apt/stable/ buster main
```

I've verified the walkthrough on Docker containers with Ubuntu 20 and 22, and Debian 9, 10, and 11.

/cc @seut, @mfussenegger, @hammerhead 