### PR TITLE
Improve wording on installation documentation

### DIFF
--- a/docs/cloud/aws/aws-terraform-setup.rst
+++ b/docs/cloud/aws/aws-terraform-setup.rst
@@ -195,7 +195,7 @@ to destroy all associated resources:
 .. _git's installation guide: https://git-scm.com/downloads
 .. _AWS provider: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
 .. _List of available AWS regions: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions
-.. _How to view VPC properties: https://docs.aws.amazon.com/vpc/latest/userguide/working-with-vpcs.html#view-vpc
-.. _How to view subnet properties: https://docs.aws.amazon.com/vpc/latest/userguide/working-with-subnets.html#view-subnet
+.. _How to view VPC properties: https://docs.aws.amazon.com/vpc/latest/userguide/create-vpc.html#view-vpc
+.. _How to view subnet properties: https://docs.aws.amazon.com/vpc/latest/userguide/what-is-amazon-vpc.html
 .. _How to create EC2 key pairs: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/create-key-pairs.html
 .. _community post: https://community.crate.io/t/deploying-cratedb-to-the-cloud-via-terraform/849

--- a/docs/cloud/aws/aws-terraform-setup.rst
+++ b/docs/cloud/aws/aws-terraform-setup.rst
@@ -195,7 +195,7 @@ to destroy all associated resources:
 .. _git's installation guide: https://git-scm.com/downloads
 .. _AWS provider: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
 .. _List of available AWS regions: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions
-.. _How to view VPC properties: https://docs.aws.amazon.com/vpc/latest/userguide/create-vpc.html#view-vpc
+.. _How to view VPC properties: https://docs.aws.amazon.com/vpc/latest/userguide/create-vpc.html
 .. _How to view subnet properties: https://docs.aws.amazon.com/vpc/latest/userguide/what-is-amazon-vpc.html
 .. _How to create EC2 key pairs: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/create-key-pairs.html
 .. _community post: https://community.crate.io/t/deploying-cratedb-to-the-cloud-via-terraform/849

--- a/docs/cloud/aws/aws-terraform-setup.rst
+++ b/docs/cloud/aws/aws-terraform-setup.rst
@@ -196,6 +196,6 @@ to destroy all associated resources:
 .. _AWS provider: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
 .. _List of available AWS regions: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions
 .. _How to view VPC properties: https://docs.aws.amazon.com/vpc/latest/userguide/default-vpc.html#view-default-vpc
-.. _How to view subnet properties: https://docs.aws.amazon.com/vpc/latest/userguide/what-is-amazon-vpc.html
+.. _How to view subnet properties: https://docs.aws.amazon.com/vpc/latest/userguide/modify-subnets.html#view-subnet
 .. _How to create EC2 key pairs: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/create-key-pairs.html
 .. _community post: https://community.crate.io/t/deploying-cratedb-to-the-cloud-via-terraform/849

--- a/docs/cloud/aws/aws-terraform-setup.rst
+++ b/docs/cloud/aws/aws-terraform-setup.rst
@@ -195,7 +195,7 @@ to destroy all associated resources:
 .. _git's installation guide: https://git-scm.com/downloads
 .. _AWS provider: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
 .. _List of available AWS regions: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions
-.. _How to view VPC properties: https://docs.aws.amazon.com/vpc/latest/userguide/create-vpc.html
+.. _How to view VPC properties: https://docs.aws.amazon.com/vpc/latest/userguide/default-vpc.html#view-default-vpc
 .. _How to view subnet properties: https://docs.aws.amazon.com/vpc/latest/userguide/what-is-amazon-vpc.html
 .. _How to create EC2 key pairs: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/create-key-pairs.html
 .. _community post: https://community.crate.io/t/deploying-cratedb-to-the-cloud-via-terraform/849

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,14 +14,14 @@ macOS and Windows systems.
 The first step to using any software package is getting it properly installed.
 Please read this section carefully.
 
-Try CrateDB Cloud
+CrateDB Cloud
 =================
 
 The easiest way to get started with CrateDB is to use a 30 day free CrateDB
 Cloud cluster, no credit card requrired. Visit the `sign up page`_ to start your
 CrateDB cluster today.
 
-Try CrateDB locally
+CrateDB locally
 ===================
 
 If you want to try out CrateDB locally on Linux or macOS but would prefer to

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ The first step to using any software package is getting it properly installed.
 Please read this section carefully.
 
 CrateDB Cloud
-=================
+=============
 
 The easiest way to get started with CrateDB is to use a 30 day free CrateDB
 Cloud cluster, no credit card requrired. Visit the `sign up page`_ to start your

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,7 +22,7 @@ Cloud cluster, no credit card requrired. Visit the `sign up page`_ to start your
 CrateDB cluster today.
 
 CrateDB locally
-===================
+===============
 
 If you want to try out CrateDB locally on Linux or macOS but would prefer to
 avoid the hassle of manual installation or extracting release archives, you can


### PR DESCRIPTION
- Wording: Remove "Try" from the headlines on the landing page.
- Fix broken links on Terraform documentation.