### PR TITLE
Remove Debian 9

### DIFF
--- a/docs/containers/docker.rst
+++ b/docs/containers/docker.rst
@@ -498,7 +498,7 @@ example::
 .. _containerization: https://www.docker.com/resources/what-container
 .. _CRATE_HEAP_SIZE: https://crate.io/docs/crate/reference/en/latest/config/environment.html#conf-env-heap-size
 .. _CrateDB Docker image: https://hub.docker.com/_/crate/
-.. _default bridge network: https://docs.docker.com/network/#network-drivers
+.. _default bridge network: https://docs.docker.com/network/drivers/bridge/#use-the-default-bridge-network
 .. _Discovery: https://crate.io/docs/crate/reference/en/latest/config/cluster.html#discovery
 .. _Docker Stack YAML file: https://docs.docker.com/docker-cloud/apps/stack-yaml-reference/
 .. _Docker Swarm: https://docs.docker.com/engine/swarm/

--- a/docs/self-hosted/debian.rst
+++ b/docs/self-hosted/debian.rst
@@ -8,7 +8,6 @@ CrateDB actively maintains packages for the following Debian versions:
 
 - `Bullseye`_ (11.x)
 - `Buster`_ (10.x)
-- `Stretch`_ (9.x)
 
 This guide will show you how to install, control, and configure a single-node
 CrateDB on a local Debian system.


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

We stopped building packages for Debian 9 in April

## Checklist

 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
