### PR TITLE
Update index.rst by removing a typo in the word required in the CrateDB Cloud section

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,7 +18,7 @@ CrateDB Cloud
 =============
 
 The easiest way to get started with CrateDB is to use a 30 day free CrateDB
-Cloud cluster, no credit card requrired. Visit the `sign up page`_ to start your
+Cloud cluster, no credit card required. Visit the `sign up page`_ to start your
 CrateDB cluster today.
 
 CrateDB locally


### PR DESCRIPTION
I removed a typo in the word "required" in the section CrateDB Cloud. It said "requrired" before.

## Summary of the changes / Why this is an improvement


## Checklist

 - [ ] Link to issue this PR refers to (if applicable): 
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
