### PR TITLE
Update Ubuntu and Debian instructions to use new repository

### DIFF
--- a/docs/basic/index.rst
+++ b/docs/basic/index.rst
@@ -97,23 +97,15 @@ the CrateDB package repository::
     # Import the public GPG key for verifying the package signatures.
     curl -sS https://cdn.crate.io/downloads/deb/DEB-GPG-KEY-crate | sudo tee /etc/apt/trusted.gpg.d/cratedb.asc
 
-    # Compute CrateDB package repository location.
-    [[ $(lsb_release --id --short) = "Debian" ]] && repository="apt"
-    [[ $(lsb_release --id --short) = "Ubuntu" ]] && repository="deb"
-    distribution=$(lsb_release --codename --short)
-
-    # Register with the CrateDB package repository.
-    echo "deb [signed-by=/etc/apt/trusted.gpg.d/cratedb.asc arch=amd64] https://cdn.crate.io/downloads/${repository}/stable/ ${distribution} main" \
-        | sudo tee /etc/apt/sources.list.d/cratedb.list
+   # Add CrateDB repository to Apt
+   sh$ echo "deb https://cdn.crate.io/downloads/debian/stable/ default main" |
+      sudo tee /etc/apt/sources.list.d/crate-stable.list
 
 .. NOTE::
 
-    CrateDB provides both *stable release* and *testing release* channels. To
-    use the testing channel, replace ``stable`` with ``testing`` in the command
-    line above. You can read more about the `release workflow`_.
-
-    The walkthrough is based on the ``sudo`` program. If it is not installed on
-    your machine, run ``apt update; apt install --yes sudo`` as a ``root`` user.
+    CrateDB provides two repositories. A *stable* and a *testing* repository. To use
+    the testing repository, replace ``stable`` with ``testing`` in the command
+    above. You can read more about our `release workflow`_.
 
 Now, update the package sources::
 

--- a/docs/self-hosted/debian.rst
+++ b/docs/self-hosted/debian.rst
@@ -27,25 +27,16 @@ CrateDB repositories:
 
 .. code-block:: sh
 
-   # Add HTTPS support
-   sh$ sudo apt install apt-transport-https
+   # Add the CrateDB GPG key
+   sh$ wget -qO- https://cdn.crate.io/downloads/apt/DEB-GPG-KEY-crate | sudo tee /etc/apt/trusted.gpg.d/crate.asc
 
-   # Download the CrateDB GPG key
-   sh$ wget https://cdn.crate.io/downloads/apt/DEB-GPG-KEY-crate
-
-   # Add the key to Apt
-   sh$ sudo apt-key add DEB-GPG-KEY-crate
-
-   # Add CrateDB repositories to Apt
-   # `lsb_release -cs` returns the codename of your OS
-   echo "deb https://cdn.crate.io/downloads/apt/stable/ $(lsb_release -cs) main" |
-     sudo tee /etc/apt/sources.list.d/crate-stable.list
-
+   # Add CrateDB repository to Apt
+   sh$ echo "deb https://cdn.crate.io/downloads/debian/stable/ default main" | sudo tee /etc/apt/sources.list.d/crate-stable.list
 
 .. NOTE::
 
-   CrateDB provides a *stable release* and a *testing release* channel. To use
-   the testing channel, replace ``stable`` with ``testing`` in the command
+   CrateDB provides two repositories. A *stable* and a *testing* repository. To use
+   the testing repository, replace ``stable`` with ``testing`` in the command
    above. You can read more about our `release workflow`_.
 
 Now update Apt:
@@ -68,10 +59,12 @@ You can now install CrateDB:
 
    sh$ sudo apt install crate
 
-After the installation is finished, the ``crate`` service should be
-up-and-running.
+After the installation is finished, you can start the ``crate`` service::
 
-You should be able to access it by visiting::
+   sh$ sudo systemctl start crate
+
+Once the service is up and running, you can access CrateDB by visiting::
+
 
   http://localhost:4200/
 

--- a/docs/self-hosted/ubuntu.rst
+++ b/docs/self-hosted/ubuntu.rst
@@ -33,15 +33,14 @@ CrateDB repositories:
    # Add the key to Apt
    sh$ sudo apt-key add DEB-GPG-KEY-crate
 
-   # Add CrateDB repositories to Apt
-   # `lsb_release -cs` returns the codename of your OS
-   sh$ sudo add-apt-repository "deb https://cdn.crate.io/downloads/deb/stable/ $(lsb_release -cs) main"
+   # Add CrateDB repository to Apt
+   sh$ sudo add-apt-repository "deb https://cdn.crate.io/downloads/debian/stable/ default main"
 
 
 .. NOTE::
 
-   CrateDB provides a *stable release* and a *testing release* channel. To use
-   the testing channel, replace ``stable`` with ``testing`` in the command
+   CrateDB provides two repositories. A *stable* and a *testing* repository. To use
+   the testing repository, replace ``stable`` with ``testing`` in the command
    above. You can read more about our `release workflow`_.
 
 Now update Apt:
@@ -64,10 +63,11 @@ You can now install CrateDB:
 
    sh$ sudo apt install crate
 
-After the installation is finished, the ``crate`` service should be
-up-and-running.
+After the installation is finished, you can start the ``crate`` service::
 
-You should be able to access it by visiting::
+   sh$ sudo systemctl start crate
+
+Once the service is up and running, you can access CrateDB by visiting::
 
   http://localhost:4200/
 


### PR DESCRIPTION
We now have a repository that only contains a single `default`
distribution, because the package is generic enough to works across all
recent Ubuntu and Debian releases.

The new repository includes old versions in the `Packages` index to
allow users to install old versions via `apt install crate=x.y.z`

It also contains ARM64 packages.
